### PR TITLE
1. Add the ability to resolve constant in replacements with replaceme…

### DIFF
--- a/src/lambdaconnect_sync/push.clj
+++ b/src/lambdaconnect_sync/push.clj
@@ -605,7 +605,9 @@
                                                           replacements (map #(some->> %
                                                                                       (get scoping-edn)
                                                                                       (:replace-fields)
-                                                                                      (keys)
+                                                                                      ;; We ignore replacements that eventually replace fields with contents of themselves (e.g. {:field-name :field-name})
+                                                                                      (filter (fn [[k v]] (not= k (constant-value v))))
+                                                                                      (map first)
                                                                                       (map name)
                                                                                       (set)) tags)]
                                                       (assert (or (<= (count replacements) 1)

--- a/test/lambdaconnect_sync/test_core.clj
+++ b/test/lambdaconnect_sync/test_core.clj
@@ -319,7 +319,7 @@
                                                   {:wow (delay true)
                                                    :are-you-there? false
                                                    :can-create? true
-                                                   :whatsupp? true                                
+                                                   :whatsupp? true                                                                                  
                                                    :some-new-fields ["lala"]})))]
                        (doall x))))))
     
@@ -356,6 +356,7 @@
                                      {:wow (delay true)
                                       :are-you-there? false
                                       :can-create? true
+                                      :lat 82.3
                                       :whatsupp? true
                                       :some-new-fields ["firstName"]}))
             {:keys [rejected-objects rejected-fields]} rejections]


### PR DESCRIPTION
…nt field name

2. Add the ability to specify replacement to be identical with the field being replaced, serving as a no-op.